### PR TITLE
Adds query string parameter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "route-manager": "./src/route-manager.js"
   },
   "devDependencies": {
+    "grunt": "~0.4.5",
     "build-tools": "^1.2.7",
     "sinon": "^1.14.1"
   },

--- a/src/route-manager.js
+++ b/src/route-manager.js
@@ -128,11 +128,43 @@ RouteManager.prototype = /** @lends RouteManager */{
      * @returns {Promise} Returns a Promise when the page of the route has loaded
      */
     triggerRoute: function (url, options) {
+        url = this.getPathName(url);
         if (url !== this._currentPath) {
             return this._onRouteRequest(url);
         } else {
             return Promise.resolve();
         }
+    },
+
+    /**
+     * Gets path name from URL.
+     * @param {string} url - The full url to navigate to.
+     * @returns {String}
+     */
+    getPathName: function (url) {
+        var url = url || window.location.href;
+        if (url.substring(0, 4) != 'http') {
+            return url;
+        } else {
+            var fakeEl = document.createElement('a');
+            fakeEl.href = url;
+            return fakeEl.pathname;
+        }
+    },
+
+    /**
+     * Gets query string params.
+     * @param {string} url - The full url to navigate to.
+     * @returns {Object} Returns an object containing query params.
+     */
+    getQueryParams: function (url) {
+        var url = url || window.location.href;
+        var params = {};
+        url.split('?')[1].split('&').forEach(function(queryParam) {
+            var splitParam = queryParam.split('=');
+            params[splitParam[0]] = splitParam[1];
+        });
+        return params;
     },
 
     /**

--- a/src/route-manager.js
+++ b/src/route-manager.js
@@ -128,27 +128,10 @@ RouteManager.prototype = /** @lends RouteManager */{
      * @returns {Promise} Returns a Promise when the page of the route has loaded
      */
     triggerRoute: function (url, options) {
-        url = this.getPathName(url);
         if (url !== this._currentPath) {
             return this._onRouteRequest(url);
         } else {
             return Promise.resolve();
-        }
-    },
-
-    /**
-     * Gets path name from URL.
-     * @param {string} url - The full url to navigate to.
-     * @returns {String}
-     */
-    getPathName: function (url) {
-        var url = url || window.location.href;
-        if (url.substring(0, 4) != 'http') {
-            return url;
-        } else {
-            var fakeEl = document.createElement('a');
-            fakeEl.href = url;
-            return fakeEl.pathname;
         }
     },
 
@@ -158,7 +141,7 @@ RouteManager.prototype = /** @lends RouteManager */{
      * @returns {Object} Returns an object containing query params.
      */
     getQueryParams: function (url) {
-        var url = url || window.location.href;
+        var url = url || this.getWindow().location.href;
         var params = {};
         url.split('?')[1].split('&').forEach(function(queryParam) {
             var splitParam = queryParam.split('=');

--- a/tests/route-manager-tests.js
+++ b/tests/route-manager-tests.js
@@ -58,20 +58,20 @@ describe('Route Manager', function () {
         requireStub.restore();
     });
 
-    it('should return path name from url', function () {
-        var RouteManager = require('route-manager')({config: {}});
-        var url = 'http://my-testable-url.com/my/testable/path';
-        RouteManager.start();
-        var pathName = RouteManager.getPathName(url);
-        assert.equal('/my/testable/path', pathName, 'path name parsed from full url: ' + pathName);
-        RouteManager.stop();
-    });
-
-    it('should return query params from url', function () {
+    it('should return query params from provided url', function () {
         var RouteManager = require('route-manager')({config: {}});
         var url = 'http://my-testable-url.com/my/testable/path/?my=little&tea=pot';
         RouteManager.start();
         var queryParams = RouteManager.getQueryParams(url);
+        assert.deepEqual({'my': 'little', 'tea': 'pot'}, queryParams, 'query params parsed from url: ' + JSON.stringify(queryParams));
+        RouteManager.stop();
+    });
+
+    it('should return query params from current window url', function () {
+        var RouteManager = require('route-manager')({config: {}});
+        RouteManager.start();
+        sinon.stub(RouteManager, 'getWindow').returns({location: {href: 'http://my-testable-url.com/my/testable/path/?my=little&tea=pot'}});
+        var queryParams = RouteManager.getQueryParams();
         assert.deepEqual({'my': 'little', 'tea': 'pot'}, queryParams, 'query params parsed from url: ' + JSON.stringify(queryParams));
         RouteManager.stop();
     });

--- a/tests/route-manager-tests.js
+++ b/tests/route-manager-tests.js
@@ -58,6 +58,24 @@ describe('Route Manager', function () {
         requireStub.restore();
     });
 
+    it('should return path name from url', function () {
+        var RouteManager = require('route-manager')({config: {}});
+        var url = 'http://my-testable-url.com/my/testable/path';
+        RouteManager.start();
+        var pathName = RouteManager.getPathName(url);
+        assert.equal('/my/testable/path', pathName, 'path name parsed from full url: ' + pathName);
+        RouteManager.stop();
+    });
+
+    it('should return query params from url', function () {
+        var RouteManager = require('route-manager')({config: {}});
+        var url = 'http://my-testable-url.com/my/testable/path/?my=little&tea=pot';
+        RouteManager.start();
+        var queryParams = RouteManager.getQueryParams(url);
+        assert.deepEqual({'my': 'little', 'tea': 'pot'}, queryParams, 'query params parsed from url: ' + JSON.stringify(queryParams));
+        RouteManager.stop();
+    });
+
     it('should fire a url change event when a url is triggered', function () {
         var RouteManager = require('route-manager')({config: {}});
         var url = 'my/testable/url';


### PR DESCRIPTION
* Adds grunt to npm ```devDependencies```
* Adds ```getPathName()``` method that will parse the path name from fully qualified URL's and relative URI's.
* Adds ```getQueryParams()``` method that returns an object containing query parameters from a provided URL (any string containing ```?key=value[&key=value...]```
* Adds basic unit tests around the above two methods

Example of getQueryString() method response:
```
http://google.com/?my=little&tea=pot   =>

{
    "my":"little",
    "tea":"pot"
}
```