### PR TITLE
update function to get previous route to include logic for 404

### DIFF
--- a/src/route-manager.js
+++ b/src/route-manager.js
@@ -489,7 +489,8 @@ RouteManager.prototype = /** @lends RouteManager */{
      * @returns {Promise} Returns promise when page is done hiding.
      */
     hidePage: function (path) {
-        var pageMap = this._pageMaps[this._getRouteMapKeyByPath(path)];
+        var route = this._getRouteMapKeyByPath(path) || '^404(/)?$',
+            pageMap = this._pageMaps[route];
         // hide previous page if exists
         if (pageMap && pageMap.promise) {
             return pageMap.promise
@@ -518,7 +519,8 @@ RouteManager.prototype = /** @lends RouteManager */{
      * @return {Promise} Returns a promise when complete
      */
     hidePageModules: function (path) {
-        var pageMap = this._pageMaps[this._getRouteMapKeyByPath(path)],
+        var route = this._getRouteMapKeyByPath(path) || '^404(/)?$',
+            pageMap = this._pageMaps[route],
             promises = [];
         // call hide on all of pages modules
         _.each(pageMap.modules, function (moduleMap) {


### PR DESCRIPTION
This is to resolve: https://jira.akqa.net/browse/BSWINSTFRN-1104.

If no path is returned for the previous page, we need to provide 404 as a fallback or else .hide() on the 404 page will never be called. I pointed my local route-manager module to this local fix and it works. Not sure if I need to run a build for this also be build into the dist/ folder or what the set up is.